### PR TITLE
fixes #3 - reload_all

### DIFF
--- a/docker/msfconsole.rc
+++ b/docker/msfconsole.rc
@@ -7,4 +7,6 @@ else
 end
 run_single("setg LHOST #{lhost}")
 run_single("db_connect #{ENV['DATABASE_URL']}") if ENV['DATABASE_URL']
+run_single("reload_all")
 </ruby>
+


### PR DESCRIPTION
Fixes #3 by adding `reload_all` to `msfconsole.rc` that gets loaded when the container starts.  The result is a slightly longer (seconds) startup time but modules are immediately searchable. 