### PR TITLE
Params should not be in quotes :(

### DIFF
--- a/docker/bin/msfvenom
+++ b/docker/bin/msfvenom
@@ -28,4 +28,4 @@ if [[ $PARAMS == *"--rebuild"* ]]; then
 fi
 
 # we need no database here
-docker-compose run --rm --no-deps ms ./msfvenom "$PARAMS"
+docker-compose run --rm --no-deps ms ./msfvenom $PARAMS


### PR DESCRIPTION
Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

Please ensure you are submitting **from a unique branch** in your [repository](https://github.com/rapid7/metasploit-framework/pull/11086#issuecomment-445506416) to master in Rapid7's.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/windows/smb/ms08_067_netapi`
- [x] ...
- [x] **Verify** the thing does what it should
- [x] **Verify** the thing does not do what it should not
- [x] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))

